### PR TITLE
Tell Gradle the file encoding is UTF-8

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,9 @@ jobs:
     # Use the WPILib docker container
     container: wpilib/roborio-cross-ubuntu:2025-24.04
 
+    env:
+      JAVA_TOOL_OPTIONS: "-Dfile.encoding=UTF-8"
+
     steps:
     - uses: actions/checkout@v4
  
@@ -30,6 +33,9 @@ jobs:
 
     # Use the WPILib docker container
     container: wpilib/roborio-cross-ubuntu:2025-24.04
+
+    env:
+      JAVA_TOOL_OPTIONS: "-Dfile.encoding=UTF-8"
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
Set the character encoding to UTF-8 so GitHub Actions doesn't spit out messages about bad characters. This was confusing when a build actually failed, since these weren't really errors.