### PR TITLE
Test mode corrections

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -111,7 +111,7 @@ public class Constants {
     // wrist constants
     public static final AngularVelocity WRIST_DOWN_SPEED = RadiansPerSecond.of(-5);
     public static final AngularVelocity WRIST_UP_SPEED = RadiansPerSecond.of(5);
-    public static final double ROLLER_SPEED_TOLERANCE = 0;
+    public static final AngularVelocity ROLLER_SPEED_TOLERANCE = RotationsPerSecond.of(3);
 
     // numbers are probably wonky here
     public static final Angle WRIST_DOWN_POSITION = Degrees.of(180);
@@ -146,7 +146,7 @@ public class Constants {
     public static final AngularVelocity INTAKE_VELOCITY = RadiansPerSecond.of(1);
     public static final AngularVelocity SCORE_VELOCITY_LEVEL_1 = RadiansPerSecond.of(-1);
     public static final AngularVelocity EJECT_VELOCITY = RadiansPerSecond.of(-2);
-    public static final double INDEXER_SPEED_TOLERANCE = 0;
+    public static final AngularVelocity INDEXER_SPEED_TOLERANCE = RotationsPerSecond.of(3);
 
     public static final Current TORQUE_CURRENT_LIMIT = Amps.of(100);
     public static final Current SUPPLY_CURRENT_LIMIT = Amps.of(10); // Placeholder, will have to change
@@ -187,8 +187,8 @@ public class Constants {
     public static final Distance ELEVATOR_TOP_LIMIT = Meters.of(0); // Placeholder
     public static final Distance ELEVATOR_BOTTOM_LIMIT = Meters.of(0); // Placeholder
 
-    public static final Angle ELEVATOR_POSITION_TOLERANCE = Rotations.of(0); // Placeholder
-    public static final Angle ARM_POSITION_TOLERANCE = Rotations.of(0); // Placeholder
+    public static final Angle ELEVATOR_POSITION_TOLERANCE = Rotations.of(3); // Placeholder
+    public static final Angle ARM_POSITION_TOLERANCE = Degrees.of(1); // Placeholder
 
     /**
      * The positions in meters the elevator could travel to with placeholder numbers for now
@@ -253,18 +253,15 @@ public class Constants {
    */
   public static class TestingConstants {
     public static final AngularVelocity INDEXER_TESTING_SPEED = RadiansPerSecond.of(2);
-    public static final AngularVelocity INDEXER_BACKWARDS_TESTING_SPEED = RadiansPerSecond
-        .of(-(INDEXER_TESTING_SPEED.in(RadiansPerSecond)));
-    public static final double INDEXER_TESTING_TOLERANCE = 0;
+    public static final AngularVelocity INDEXER_BACKWARDS_TESTING_SPEED = INDEXER_TESTING_SPEED.unaryMinus();
+    public static final AngularVelocity INDEXER_TESTING_SPEED_TOLERANCE = RotationsPerSecond.of(3);
 
     public static final AngularVelocity MANIPULATOR_TESTING_SPEED = RadiansPerSecond.of(2);
-    public static final AngularVelocity MANIPULATOR_BACKWARDS_TESTING_SPEED = RadiansPerSecond
-        .of(-(MANIPULATOR_TESTING_SPEED.in(RadiansPerSecond)));
-    public static final double MANIPULATOR_TESTING_TOLERANCE = 0;
+    public static final AngularVelocity MANIPULATOR_BACKWARDS_TESTING_SPEED = MANIPULATOR_TESTING_SPEED.unaryMinus();
+    public static final AngularVelocity MANIPULATOR_TESTING_SPEED_TOLERANCE = RotationsPerSecond.of(3);
 
     public static final AngularVelocity ROLLER_TESTING_SPEED = RadiansPerSecond.of(5);
-    public static final AngularVelocity ROLLER_BACKWARDS_TESTING_SPEED = RadiansPerSecond
-        .of(-(ROLLER_TESTING_SPEED.in(RadiansPerSecond)));
+    public static final AngularVelocity ROLLER_BACKWARDS_TESTING_SPEED = ROLLER_TESTING_SPEED.unaryMinus();
 
     public static final Voltage CLIMB_TESTING_VOLTAGE = Volts.of(5);
   }

--- a/src/main/java/frc/robot/commands/TestCommand.java
+++ b/src/main/java/frc/robot/commands/TestCommand.java
@@ -29,11 +29,14 @@ public class TestCommand extends Command {
   private final ClimbSubsystem climbSubsystem;
   private final ArmSubsystem armSubsystem;
 
+  private final Timer timer = new Timer();
+
   private boolean hasStopped = false;
   private int teststate = 0;
 
-  private Timer timer = new Timer();
-
+  /**
+   * Creates a TestCommand
+   */
   public TestCommand(
       IndexerSubsystem indexersubsystem,
       GamePieceManipulatorSubsystem gamePieceManipulatorSubsystem,
@@ -59,9 +62,6 @@ public class TestCommand extends Command {
   @Override
   public void execute() {
     switch (teststate) {
-      default:
-        break;
-
       case 0:
         if (!hasStopped) {
           indexersubsystem.runBelt(INDEXER_TESTING_SPEED);
@@ -247,6 +247,9 @@ public class TestCommand extends Command {
           hasStopped = false;
         }
         break;
+
+      default:
+        break;
     }
   }
 
@@ -261,7 +264,7 @@ public class TestCommand extends Command {
 
   @Override
   public boolean isFinished() {
-    return !RobotState.isTest();
+    return teststate > 10 || !RobotState.isTest();
   }
 
   @Override

--- a/src/main/java/frc/robot/subsystems/AlgaeSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/AlgaeSubsystem.java
@@ -6,6 +6,7 @@ package frc.robot.subsystems;
 
 import static com.ctre.phoenix6.signals.NeutralModeValue.Brake;
 import static edu.wpi.first.units.Units.Rotations;
+import static edu.wpi.first.units.Units.RotationsPerSecond;
 import static edu.wpi.first.units.Units.Second;
 import static edu.wpi.first.units.Units.Volts;
 import static frc.robot.Constants.AlgaeConstants.DEVICE_ID_CANCODER;
@@ -179,9 +180,9 @@ public class AlgaeSubsystem extends SubsystemBase {
   }
 
   /**
-   * Method to run the rollers at any specific speed
+   * Runs the rollers at any specific speed
    * 
-   * @param speed in rotations
+   * @param speed speed to run the rollers
    */
   public void runRollers(AngularVelocity speed) {
     rollerMotor.setControl(rollerControl.withVelocity(speed));
@@ -255,6 +256,9 @@ public class AlgaeSubsystem extends SubsystemBase {
    * @return if its spinning at the proper speed as a boolean value
    */
   public boolean isAtRollerSpeed() {
-    return (Math.abs(wristVelocity.getValueAsDouble() - rollerControl.Velocity) <= ROLLER_SPEED_TOLERANCE);
+    return wristVelocity.refresh()
+        .getValue()
+        .minus(rollerControl.getVelocityMeasure())
+        .abs(RotationsPerSecond) <= ROLLER_SPEED_TOLERANCE.in(RotationsPerSecond);
   }
 }

--- a/src/main/java/frc/robot/subsystems/ArmSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/ArmSubsystem.java
@@ -349,9 +349,10 @@ public class ArmSubsystem extends SubsystemBase {
    * @return true if the elevator is at the target position, within a tolerance
    */
   public boolean isElevatorAtPosition() {
-    return Math
-        .abs(elevatorControl.Position - elevatorPositionSignal.getValue().in(Rotations)) < ELEVATOR_POSITION_TOLERANCE
-            .in(Rotations);
+    return elevatorPositionSignal.refresh()
+        .getValue()
+        .minus(elevatorControl.getPositionMeasure())
+        .abs(Rotations) <= ELEVATOR_POSITION_TOLERANCE.in(Rotations);
   }
 
   /**
@@ -360,7 +361,9 @@ public class ArmSubsystem extends SubsystemBase {
    * @return true if the arm is at the target position, within a tolerance
    */
   public boolean isArmAtPosition() {
-    return Math.abs(armControl.Position - armPositionSignal.getValue().in(Rotations)) < ARM_POSITION_TOLERANCE
-        .in(Rotations);
+    return armPositionSignal.refresh()
+        .getValue()
+        .minus(armControl.getPositionMeasure())
+        .abs(Rotations) <= ARM_POSITION_TOLERANCE.in(Rotations);
   }
 }


### PR DESCRIPTION
- CTRE StatusSignals need to be refreshed or they will return stale data. The tolerance checks didn't refresh
- Tolerances (and any other measures) should use the units library
- A tolerance of zero is too low
- Javadoc comments aren't correct:
  - several start with "Method to". See https://google.github.io/styleguide/javaguide.html#s7.2-summary-fragment
  - parameters aren't described right "to run the belt in radians per second"
  - when using the units library, parameters are a measure with a dimension, but no unit. The parameter is not "in radians per second", it's merely an angular velocity
- Much of GamePieceManipulatorSubsystem's constructor got moved into the runManipulatorWheels() method
- The .unaryMinus() method can be used on a measure to negate it
- Naming should be consistent - "belt" is the name that was used for the belt, not "indexer"
- StatusSignals return a position, so the variable name should say "position" not "rotations"

I would really prefer to have TestCommand be multiple commands that are composed to run in sequence. The switch block is nearly 200 lines and the command uses all of the subsystems, but none of them are operated together. The command is trying to do iterative coding within a command-based robot.
Could we instead have a sequence of commands that run, each scheduled with timeout, that report a pass or fail status to the NT? Currently, if a test doesn't pass it just runs forever and the other tests don't run.