### PR TITLE
Vision fixes

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -43,6 +43,9 @@ public class Constants {
 
   public static final String CANIVORE_BUS_NAME = "canivore";
 
+  /**
+   * Constants for vision processing
+   */
   public static class VisionConstants {
     public static final String kCameraName = "YOUR CAMERA NAME";
     // Cam mounted facing forward, half a meter forward of center, half a meter up from center.
@@ -51,7 +54,7 @@ public class Constants {
         new Rotation3d(0, 0, 0));
 
     // The layout of the AprilTags on the field
-    public static final AprilTagFieldLayout kTagLayout = AprilTagFields.kDefaultField.loadAprilTagLayoutField();
+    public static final AprilTagFieldLayout kTagLayout = AprilTagFieldLayout.loadField(AprilTagFields.k2025Reefscape);
 
     // The standard deviations of our vision estimated poses, which affect correction rate
     // (Fake values. Experiment and determine estimation noise on an actual robot.)

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -48,7 +48,7 @@ public class RobotContainer {
   private final IndexerSubsystem indexerSubsystem = new IndexerSubsystem();
   private final CommandSwerveDrivetrain drivetrain = TunerConstants.createDrivetrain();
   private final DrivetrainTelemetry drivetrainTelemetry = new DrivetrainTelemetry(MaxSpeed);
-  private final PhotonVisionCommand visionCommand = new PhotonVisionCommand(drivetrain);
+  private final PhotonVisionCommand visionCommand = new PhotonVisionCommand(drivetrain::addVisionMeasurement);
 
   /* Path follower */
   private final SendableChooser<Command> autoChooser;

--- a/src/main/java/frc/robot/commands/PhotonVisionCommand.java
+++ b/src/main/java/frc/robot/commands/PhotonVisionCommand.java
@@ -1,19 +1,24 @@
 package frc.robot.commands;
 
-import com.ctre.phoenix6.Utils;
 import edu.wpi.first.wpilibj2.command.Command;
-import frc.robot.Vision;
-import frc.robot.subsystems.CommandSwerveDrivetrain;
+import frc.robot.vision.Vision;
+import frc.robot.vision.VisionConsumer;
 
+/**
+ * Command to use PhotonVision to process pose estimates and pass them to a pose estimator
+ */
 public class PhotonVisionCommand extends Command {
   private final Vision vision;
-  private final CommandSwerveDrivetrain drivetrain;
+  private final VisionConsumer visionConsumer;
 
-  public PhotonVisionCommand(CommandSwerveDrivetrain drivetrain) {
+  /**
+   * Constructs a PhotonVisionCommand
+   * 
+   * @param consumer consumer to receive vision estimates
+   */
+  public PhotonVisionCommand(VisionConsumer consumer) {
     this.vision = new Vision();
-    this.drivetrain = drivetrain;
-
-    addRequirements(drivetrain);
+    this.visionConsumer = consumer;
   }
 
   @Override
@@ -24,12 +29,13 @@ public class PhotonVisionCommand extends Command {
       // Change our trust in the measurement based on the tags we can see
       var estStdDevs = vision.getEstimationStdDevs();
 
-      drivetrain.addVisionMeasurement(
-          est.estimatedPose.toPose2d(),
-            Utils.fpgaToCurrentTime(est.timestampSeconds),
-            estStdDevs);
+      visionConsumer.addVisionMeasurement(est.estimatedPose.toPose2d(), est.timestampSeconds, estStdDevs);
     });
+  }
 
+  @Override
+  public boolean runsWhenDisabled() {
+    return true;
   }
 
 }

--- a/src/main/java/frc/robot/subsystems/CommandSwerveDrivetrain.java
+++ b/src/main/java/frc/robot/subsystems/CommandSwerveDrivetrain.java
@@ -12,6 +12,7 @@ import com.pathplanner.lib.config.PIDConstants;
 import com.pathplanner.lib.config.RobotConfig;
 import com.pathplanner.lib.controllers.PPHolonomicDriveController;
 import edu.wpi.first.math.Matrix;
+import edu.wpi.first.math.geometry.Pose2d;
 import edu.wpi.first.math.geometry.Rotation2d;
 import edu.wpi.first.math.numbers.N1;
 import edu.wpi.first.math.numbers.N3;
@@ -259,5 +260,41 @@ public class CommandSwerveDrivetrain extends TunerSwerveDrivetrain implements Su
       updateSimState(deltaTime, RobotController.getBatteryVoltage());
     });
     m_simNotifier.startPeriodic(kSimLoopPeriod);
+  }
+
+  /**
+   * Adds a vision measurement to the Kalman Filter. This will correct the odometry pose estimate
+   * while still accounting for measurement noise.
+   *
+   * @param visionRobotPoseMeters The pose of the robot as measured by the vision camera.
+   * @param timestampSeconds The timestamp of the vision measurement in seconds.
+   */
+  @Override
+  public void addVisionMeasurement(Pose2d visionRobotPoseMeters, double timestampSeconds) {
+    super.addVisionMeasurement(visionRobotPoseMeters, Utils.fpgaToCurrentTime(timestampSeconds));
+  }
+
+  /**
+   * Adds a vision measurement to the Kalman Filter. This will correct the odometry pose estimate
+   * while still accounting for measurement noise.
+   * <p>
+   * Note that the vision measurement standard deviations passed into this method
+   * will continue to apply to future measurements until a subsequent call to
+   * {@link #setVisionMeasurementStdDevs(Matrix)} or this method.
+   *
+   * @param visionRobotPoseMeters The pose of the robot as measured by the vision camera.
+   * @param timestampSeconds The timestamp of the vision measurement in seconds.
+   * @param visionMeasurementStdDevs Standard deviations of the vision pose measurement
+   *          in the form [x, y, theta]ᵀ, with units in meters and radians.
+   */
+  @Override
+  public void addVisionMeasurement(
+      Pose2d visionRobotPoseMeters,
+      double timestampSeconds,
+      Matrix<N3, N1> visionMeasurementStdDevs) {
+    super.addVisionMeasurement(
+        visionRobotPoseMeters,
+          Utils.fpgaToCurrentTime(timestampSeconds),
+          visionMeasurementStdDevs);
   }
 }

--- a/src/main/java/frc/robot/vision/Vision.java
+++ b/src/main/java/frc/robot/vision/Vision.java
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-package frc.robot;
+package frc.robot.vision;
 
 import static frc.robot.Constants.VisionConstants.*;
 
@@ -47,6 +47,9 @@ public class Vision {
   private final PhotonPoseEstimator photonEstimator;
   private Matrix<N3, N1> curStdDevs;
 
+  /**
+   * Constructs a new Vision instance
+   */
   public Vision() {
     camera = new PhotonCamera(kCameraName);
 

--- a/src/main/java/frc/robot/vision/VisionConsumer.java
+++ b/src/main/java/frc/robot/vision/VisionConsumer.java
@@ -1,0 +1,28 @@
+package frc.robot.vision;
+
+import edu.wpi.first.math.Matrix;
+import edu.wpi.first.math.geometry.Pose2d;
+import edu.wpi.first.math.numbers.N1;
+import edu.wpi.first.math.numbers.N3;
+
+/**
+ * Consumer that uses vision measurements. Usually implemented by the drivetrain to pass data to a pose estimator.
+ */
+@FunctionalInterface
+public interface VisionConsumer {
+  /**
+   * Adds a vision measurement.
+   * <p>
+   * Note that the vision measurement standard deviations passed into this method
+   * will continue to apply to future measurements.
+   *
+   * @param visionRobotPoseMeters The pose of the robot as measured by the vision camera.
+   * @param timestampSeconds The timestamp of the vision measurement in seconds.
+   * @param visionMeasurementStdDevs Standard deviations of the vision pose measurement in the form [x, y, theta]ᵀ, with
+   *          units in meters and radians.
+   */
+  public void addVisionMeasurement(
+      Pose2d visionRobotPoseMeters,
+      double timestampSeconds,
+      Matrix<N3, N1> visionMeasurementStdDevs);
+}


### PR DESCRIPTION
I tried this at Big Lake and I found a couple problems:
- The command needs to run when disabled. It was immediately stopping because it was scheduled while the robot was disabled.
- The command was requiring the drivetrain, so nothing else could use it.
I also noticed loading the field changed, the old was is deprecated.
Finally, the CTRE generated CommandDriveTrain now includes an `addVisionMeasurement` override that does the timestamp conversion, so I updated our project to do the same.